### PR TITLE
Enhance the to **MenuItem and fix a crash issue of reading properties of null (reading 'children') in isSubmenuFocused method.

### DIFF
--- a/packages/mui-nested-menu/src/components/IconMenuItem.tsx
+++ b/packages/mui-nested-menu/src/components/IconMenuItem.tsx
@@ -27,6 +27,7 @@ type IconMenuItemProps = {
     className?: string;
     disabled?: boolean;
     label?: string;
+    renderLabel?: () => React.ReactNode;
     leftIcon?: React.ReactNode;
     onClick?: (event: React.MouseEvent<HTMLElement>) => void;
     ref?: RefObject<HTMLLIElement>;
@@ -35,14 +36,14 @@ type IconMenuItemProps = {
 };
 
 export const IconMenuItem = forwardRef<HTMLLIElement, IconMenuItemProps>(function IconMenuItem(
-    { MenuItemProps, className, label, leftIcon, rightIcon, ...props },
+    { MenuItemProps, className, label, leftIcon, renderLabel, rightIcon, ...props },
     ref
 ) {
     return (
         <StyledMenuItem {...MenuItemProps} ref={ref} className={className} {...props}>
             <FlexBox>
                 {leftIcon}
-                <StyledTypography>{label}</StyledTypography>
+                {renderLabel ? renderLabel() : <StyledTypography>{label}</StyledTypography>}
             </FlexBox>
             {rightIcon}
         </StyledMenuItem>

--- a/packages/mui-nested-menu/src/components/NestedMenuItem.tsx
+++ b/packages/mui-nested-menu/src/components/NestedMenuItem.tsx
@@ -21,6 +21,7 @@ export type NestedMenuItemProps = Omit<MenuItemProps, 'button'> & {
     parentMenuOpen: boolean;
     component?: ElementType;
     label?: string;
+    renderLabel?: () => ReactNode;
     rightIcon?: ReactNode;
     leftIcon?: ReactNode;
     children?: ReactNode;
@@ -39,6 +40,7 @@ const NestedMenuItem = forwardRef<HTMLLIElement | null, NestedMenuItemProps>(fun
     const {
         parentMenuOpen,
         label,
+        renderLabel,
         rightIcon = <ChevronRight />,
         leftIcon = null,
         children,
@@ -145,6 +147,7 @@ const NestedMenuItem = forwardRef<HTMLLIElement | null, NestedMenuItemProps>(fun
                 leftIcon={leftIcon}
                 rightIcon={rightIcon}
                 label={label}
+                renderLabel={renderLabel}
             />
 
             <Menu

--- a/packages/mui-nested-menu/src/components/NestedMenuItem.tsx
+++ b/packages/mui-nested-menu/src/components/NestedMenuItem.tsx
@@ -81,8 +81,10 @@ const NestedMenuItem = forwardRef<HTMLLIElement | null, NestedMenuItemProps>(fun
     // Check if any immediate children are active
     const isSubmenuFocused = () => {
         const active = containerRef.current?.ownerDocument.activeElement ?? null;
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        for (const child of menuContainerRef.current!.children) {
+        if(menuContainerRef.current == null) {
+            return false;
+        }
+        for (const child of menuContainerRef.current.children) {
             if (child === active) {
                 return true;
             }


### PR DESCRIPTION
bugfix(NestedMenuItem): The app crash when we open the menu and then use the keyboard to navigate to the Nested Menu.
feature (**MenuItem):  provide a render method to customize the menu item label.