### PR TITLE
🌟 feat(mui-nested-menu): add delay prop to open nested menu with delay

### DIFF
--- a/apps/docs/src/pages/ContextMenuPage.tsx
+++ b/apps/docs/src/pages/ContextMenuPage.tsx
@@ -72,6 +72,17 @@ const menuItemsData: MenuItemData[] = [
         leftIcon: <AdbIcon />,
         rightIcon: <AdbIcon />,
     },
+    {
+        delay: 500,
+        items: [
+            {
+                callback: (event: React.MouseEvent<HTMLElement>, item: MenuItemData) =>
+                    console.log('Delay in ms to prevent blinking on hovering > I was delayed! clicked', event, item),
+                label: 'I was delayed!',
+            },
+        ],
+        label: 'Delay in ms to prevent blinking on hovering',
+    },
 ];
 
 export const ContextMenuPage: FC = () => {
@@ -186,6 +197,17 @@ export const ContextMenuPage: FC = () => {
       },
     ],
   },
+  {
+    delay: 500,
+    items: [
+        {
+            callback: (event: React.MouseEvent<HTMLElement>, item: MenuItemData) =>
+                console.log('Delay in ms to prevent blinking on hovering > I was delayed! clicked', event, item),
+            label: 'I was delayed!',
+        },
+    ],
+    label: 'Delay in ms to prevent blinking on hovering',
+},
 ]`}
             />
         </Fragment>

--- a/apps/docs/src/pages/NestedMenuItemPage.tsx
+++ b/apps/docs/src/pages/NestedMenuItemPage.tsx
@@ -65,6 +65,14 @@ export const NestedMenuItemPage = () => {
                                         label="Icon Menu Item"
                                     />
                                 </NestedMenuItem>
+                                <NestedMenuItem
+                                    rightIcon={<ArrowRightIcon />}
+                                    label="Delay in ms to prevent blinking on hovering"
+                                    parentMenuOpen={open}
+                                    delay={500}
+                                >
+                                    <MenuItem onClick={handleClose}>I was delayed!</MenuItem>
+                                </NestedMenuItem>
                             </NestedMenuItem>
                         </Menu>
                     </div>
@@ -113,6 +121,14 @@ return (
             rightIcon={<SaveIcon />}
             label="Icon Menu Item"
           />
+        </NestedMenuItem>
+        <NestedMenuItem
+          rightIcon={<ArrowRightIcon />}
+          label="Delay in ms to prevent blinking on hovering"
+          parentMenuOpen={open}
+          delay={500}
+        >
+          <MenuItem onClick={handleClose}>I was delayed!</MenuItem>
         </NestedMenuItem>
       </NestedMenuItem>
     </Menu>

--- a/packages/mui-nested-menu/src/components/NestedMenuItem.tsx
+++ b/packages/mui-nested-menu/src/components/NestedMenuItem.tsx
@@ -31,6 +31,7 @@ export type NestedMenuItemProps = Omit<MenuItemProps, 'button'> & {
     ContainerProps?: HTMLAttributes<HTMLElement> & RefAttributes<HTMLElement | null>;
     MenuProps?: Partial<Omit<MenuProps, 'children'>>;
     button?: true | undefined;
+    delay?: number;
 };
 
 const NestedMenuItem = forwardRef<HTMLLIElement | null, NestedMenuItemProps>(function NestedMenuItem(
@@ -48,6 +49,7 @@ const NestedMenuItem = forwardRef<HTMLLIElement | null, NestedMenuItemProps>(fun
         tabIndex: tabIndexProp,
         ContainerProps: ContainerPropsProp = {},
         MenuProps,
+        delay = 0,
         ...MenuItemProps
     } = props;
 
@@ -61,16 +63,23 @@ const NestedMenuItem = forwardRef<HTMLLIElement | null, NestedMenuItemProps>(fun
 
     const menuContainerRef = useRef<HTMLDivElement | null>(null);
 
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
     const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
 
     const handleMouseEnter = (e: MouseEvent<HTMLElement>) => {
-        setIsSubMenuOpen(true);
+        timeoutRef.current = setTimeout(() => {
+            setIsSubMenuOpen(true);
 
-        if (ContainerProps.onMouseEnter) {
-            ContainerProps.onMouseEnter(e);
-        }
+            if (ContainerProps.onMouseEnter) {
+                ContainerProps.onMouseEnter(e);
+            }
+        }, delay);
     };
+    
     const handleMouseLeave = (e: MouseEvent<HTMLElement>) => {
+        timeoutRef.current && clearTimeout(timeoutRef.current);
+
         setIsSubMenuOpen(false);
 
         if (ContainerProps.onMouseLeave) {

--- a/packages/mui-nested-menu/src/components/nestedMenuItemsFromObject.tsx
+++ b/packages/mui-nested-menu/src/components/nestedMenuItemsFromObject.tsx
@@ -20,7 +20,7 @@ export function nestedMenuItemsFromObject({
     handleClose,
 }: nestedMenuItemsFromObjectProps) {
     return items.map((item) => {
-        const { leftIcon, rightIcon, label, items, callback, sx, disabled } = item;
+        const { leftIcon, rightIcon, label, items, callback, sx, disabled, delay } = item;
 
         if (items && items.length > 0) {
             // Recurse deeper
@@ -32,6 +32,7 @@ export function nestedMenuItemsFromObject({
                     label={label}
                     parentMenuOpen={isOpen}
                     sx={sx}
+                    delay={delay}
                     disabled={disabled}
                 >
                     {/* Call this function to nest more items */}

--- a/packages/mui-nested-menu/src/definitions.ts
+++ b/packages/mui-nested-menu/src/definitions.ts
@@ -9,4 +9,5 @@ export interface MenuItemData {
     items?: MenuItemData[];
     disabled?: boolean;
     sx?: SxProps;
+    delay?: number;
 }


### PR DESCRIPTION
Add an option to delay the display of nested menus to avoid blinking when moving the mouse quickly to get to the desired item. Instead of just a simple on/off setting with a predefined delay, you can choose the time (in ms) for better control.


It's a UX standard of most (if not all) apps, so I think it's worth having it in this great package.


| Without Delay    | With delay (300 ms) |
| -------- | ------- |
|![no-delay](https://github.com/webzep/mui-nested-menu/assets/8067006/539c1089-9790-475d-886d-5882050a2f5c)|![with-delay](https://github.com/webzep/mui-nested-menu/assets/8067006/a32ad5c2-febf-443a-8c2c-0652c55431e7)|


Additionally, updated the Documentation page to include a delay example.

